### PR TITLE
Prevent reusing names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ class LocalStorage extends Service {
     if (usedKeys.indexOf(this._storageKey) === -1) {
       usedKeys.push(this._storageKey);
     } else {
-      throw new Error(`The storage name '${this._storageKey}' is already in use by another instance.`)
+      throw new Error(`The storage name '${this._storageKey}' is already in use by another instance.`);
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 const { Service } = require('feathers-memory');
 
+const usedKeys = [];
+
 class LocalStorage extends Service {
   constructor (options = {}) {
     super(options);
@@ -10,6 +12,12 @@ class LocalStorage extends Service {
 
     if (!this._storage) {
       throw new Error('The `storage` option needs to be provided');
+    }
+
+    if (usedKeys.indexOf(this._storageKey) === -1) {
+      usedKeys.push(this._storageKey);
+    } else {
+      throw new Error(`The storage name '${this._storageKey}' is already in use by another instance.`)
     }
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,9 +11,9 @@ describe('Feathers Localstorage Service', () => {
 
   const events = [ 'testing' ];
   const app = feathers()
-    .use('/people', service({ events, storage }))
+    .use('/people', service({ events, storage, name: 'test-storage-1' }))
     .use('/people-customid', service({
-      id: 'customid', events, storage
+      id: 'customid', events, storage, name: 'test-storage-2'
     }));
 
   it('is CommonJS compatible', () => {
@@ -21,7 +21,7 @@ describe('Feathers Localstorage Service', () => {
   });
 
   it('loads and sets data in storage', () => {
-    const name = 'test-storage';
+    const name = 'test-storage-3';
 
     storage.setItem(name, '{ "0": { "id": 0, "text": "test 0" } }');
 
@@ -74,7 +74,7 @@ describe('Feathers Localstorage Service', () => {
   });
 
   it('gets data in storage', done => {
-    const name = 'test-storage';
+    const name = 'test-storage-4';
 
     storage.setItem(name, '{ "0": { "id": 0, "text": "test 0" } }');
 
@@ -97,6 +97,17 @@ describe('Feathers Localstorage Service', () => {
         });
       });
     }).then(done, done);
+  });
+
+  it('throws on name reuse', done => {
+    const name = 'test-storage-5';
+
+    assert.throws(() => {
+      service({ storage, name });
+      service({ storage, name });
+    });
+
+    done();
   });
 
   base(app, errors);


### PR DESCRIPTION
Reusing storage keys leads to undefined behavior, so it shouldn't be possible.

This is a breaking change. 
Although technically any application reusing storage keys could be considered broken already.